### PR TITLE
Prev selected button border

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Tabs/TabsTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Tabs/TabsTest.tsx
@@ -21,7 +21,7 @@ const tabs: React.FunctionComponent<{}> = () => {
   return (
     <View>
       <View style={stackStyle}>
-        <Tabs label="Tabs" onTabsClick={onTabsClick}>
+        <Tabs label="Tabs" defaultSelectedKey="B" onTabsClick={onTabsClick}>
           <TabsItem icon={{ svgSource: svgProps, width: 20, height: 20, color: 'red' }} headerText="Option A!" buttonKey="A" />
           <TabsItem headerText="Option B" buttonKey="B" />
           <TabsItem headerText="Option C" buttonKey="C" />

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -6,7 +6,7 @@ export const tabsItemSelectActionLabel = 'Select a TabsItem';
 export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
-      borderColor: 'buttonBorder',
+      borderColor: 'transparent',
       color: 'black',
       backgroundColor: 'transparent',
       textBorderColor: 'transparent',
@@ -23,8 +23,9 @@ export const settings: IComposeSettings<TabsItemType> = [
       selected: {
         tokens: {
           backgroundColor: 'buttonBackgroundPressed',
-          color: 'blue',
+          color: 'black',
           borderColor: 'blue',
+          borderWidth: 2,
         },
       },
       focused: {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ X ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

(a summary of the changes made, often organized by file)
TabsItem.settings.ts
- fixed the bug where a button that was selected previously had a smaller outside border even after it was not selected anymore
Tabstest.tsx
- a basic implementation of default selected key

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
