### PR TITLE
New style

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Tabs/TabsTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Tabs/TabsTest.tsx
@@ -51,8 +51,8 @@ const tabChangingViews: React.FunctionComponent<{}> = () => {
         <TabsItem headerText="File" buttonKey="file" disabled={true} />
         <TabsItem headerText="Settings" buttonKey="settings" />
       </Tabs>
-      <Separator />
-      <View>
+      {/* <Separator /> */}
+      <View style={{ marginVertical: 1 }}>
         {selectedKey == 'home' && <Text>This is home</Text>}
         {selectedKey == 'file' && <Text>This is file</Text>}
         {selectedKey == 'settings' && <Text>This is settings</Text>}

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Tabs/TabsTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Tabs/TabsTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { View } from 'react-native';
-import { Tabs, TabsItem, Text, Separator } from '@fluentui/react-native';
+import { Tabs, TabsItem, Text } from '@fluentui/react-native';
 import { stackStyle } from '../Common/styles';
 import { TABS_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
@@ -51,7 +51,6 @@ const tabChangingViews: React.FunctionComponent<{}> = () => {
         <TabsItem headerText="File" buttonKey="file" disabled={true} />
         <TabsItem headerText="Settings" buttonKey="settings" />
       </Tabs>
-      {/* <Separator /> */}
       <View style={{ marginVertical: 1 }}>
         {selectedKey == 'home' && <Text>This is home</Text>}
         {selectedKey == 'file' && <Text>This is file</Text>}

--- a/packages/components/Tabs/src/Tabs.settings.ts
+++ b/packages/components/Tabs/src/Tabs.settings.ts
@@ -21,6 +21,7 @@ export const settings: IComposeSettings<TabsType> = [
     container: {
       style: {
         flexDirection: 'row',
+        backgroundColor: '#FAFAFA',
       },
     },
   },

--- a/packages/components/Tabs/src/Tabs.tsx
+++ b/packages/components/Tabs/src/Tabs.tsx
@@ -8,7 +8,7 @@ import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose'
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { settings } from './Tabs.settings';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
-import { foregroundColorTokens, textTokens } from '@fluentui-react-native/tokens';
+import { foregroundColorTokens, textTokens, backgroundColorTokens } from '@fluentui-react-native/tokens';
 import { useSelectedKey } from '@fluentui-react-native/interactive-hooks';
 
 export const TabsContext = React.createContext<ITabsContext>({
@@ -117,7 +117,7 @@ export const Tabs = compose<TabsType>({
   styles: {
     root: [],
     label: [foregroundColorTokens, textTokens],
-    container: [],
+    container: [backgroundColorTokens],
   },
 });
 

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -35,7 +35,6 @@ export const settings: IComposeSettings<TabsItemType> = [
         backgroundColor: 'transparent',
         borderRadius: 2,
         marginBottom: 2,
-        // zIndex: 2,
       },
     },
     stack: {

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -9,11 +9,11 @@ export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
       color: '#616161',
+      fontWeight: 'normal',
+      fontFamily: 'Segoe UI',
       borderWidth: 0,
       borderRadius: 0,
       fontSize: 14,
-      fontWeight: 'normal',
-      fontFamily: 'Segoe UI',
     },
     root: {
       accessible: true,
@@ -32,13 +32,15 @@ export const settings: IComposeSettings<TabsItemType> = [
         // flex: 1,
         minHeight: 2,
         minWidth: 44,
-        backgroundColor: '#185ABD',
+        backgroundColor: 'transparent',
         borderRadius: 2,
         marginBottom: 2,
+        // zIndex: 2,
       },
     },
     stack: {
       style: {
+        // backgroundColor: '#FAFAFA',
         display: 'flex',
         marginHorizontal: 10,
         alignItems: 'center',
@@ -49,21 +51,26 @@ export const settings: IComposeSettings<TabsItemType> = [
         justifyContent: 'center',
       },
     },
-    _precedence: ['hovered', 'selected', 'focused', 'disabled'],
+    _precedence: ['hovered', 'pressed', 'selected', 'focused', 'disabled'],
     _overrides: {
       disabled: {
         tokens: {
-          backgroundColor: 'buttonBackgroundDisabled',
-          color: 'buttonTextDisabled',
-          borderColor: 'buttonBorderDisabled',
+          // backgroundColor: 'buttonBackgroundDisabled',
+          color: '#BDBDBD',
+          // borderColor: 'buttonBorderDisabled',
         },
       },
       hovered: {
         tokens: {
           color: '#242424',
-          fontWeight: 'bold',
-          fontFamily: 'Segoe UI',
-          fontSize: 14,
+          // fontWeight: 'bold',
+          // fontFamily: 'Segoe UI',
+          // fontSize: 14,
+        },
+        indicator: {
+          style: {
+            backgroundColor: '#D1D1D1',
+          },
         },
       },
       selected: {
@@ -74,12 +81,27 @@ export const settings: IComposeSettings<TabsItemType> = [
           fontSize: 14,
         },
       },
+      pressed: {
+        tokens: {
+          color: '#242424',
+        },
+        indicator: {
+          style: {
+            backgroundColor: '#0078D4',
+          },
+        },
+      },
       focused: {
         tokens: {
           color: '#242424',
           borderWidth: 2,
           borderColor: '#242424',
           borderRadius: 4,
+        },
+        indicator: {
+          style: {
+            backgroundColor: '#0078D4',
+          },
         },
       },
     },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -7,11 +7,14 @@ export const tabsItemSelectActionLabel = 'Select a TabsItem';
 export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
-      backgroundColor: 'transparent', // used to be 'buttonBackground'
-      color: 'black',
-      borderColor: 'black',
+      backgroundColor: 'transparent',
+      color: 'buttonTextPressed',
+      borderColor: 'buttonTextPressed',
       borderWidth: 0,
       borderRadius: 0,
+      fontSize: 14,
+      fontWeight: 'normal',
+      fontFamily: 'inherit',
     },
     root: {
       accessible: true,
@@ -57,26 +60,26 @@ export const settings: IComposeSettings<TabsItemType> = [
           borderColor: 'buttonBorderHovered',
           fontWeight: 'bold',
           fontFamily: 'inherit',
-          fontSize: 13,
+          fontSize: 14,
         },
       },
       selected: {
         tokens: {
           backgroundColor: 'transparent',
           color: 'buttonTextPressed',
-          borderColor: 'buttonPressedBorder',
+          // borderColor: 'buttonBorderPressed',
           borderWidth: 0,
           fontWeight: 'bold',
           fontFamily: 'inherit',
-          fontSize: 13,
+          fontSize: 14,
         },
       },
       focused: {
         tokens: {
-          borderColor: 'black',
-          color: 'buttonTextFocused',
+          borderColor: 'buttonBorderFocused',
+          color: 'buttonTextFocused', // invalid prop?
           backgroundColor: 'transparent',
-          borderWidth: 4,
+          borderWidth: 3,
         },
       },
     },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -1,6 +1,7 @@
 import { tabsItemName, TabsItemType } from './TabsItem.types';
 import { IComposeSettings } from '@uifabricshared/foundation-compose';
 import type { IViewProps } from '@fluentui-react-native/adapters';
+// import { Text } from '@fluentui-react-native/experimental-text';
 
 export const tabsItemSelectActionLabel = 'Select a TabsItem';
 
@@ -8,8 +9,9 @@ export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
       // backgroundColor: 'transparent',
-      color: '#616161',
       // borderColor: 'transparent',
+      // color: 'AccentDark',
+      color: '#616161',
       borderWidth: 0,
       borderRadius: 0,
       fontSize: 14,
@@ -25,6 +27,7 @@ export const settings: IComposeSettings<TabsItemType> = [
         alignItems: 'center',
         flexDirection: 'column',
         alignSelf: 'flex-start',
+        justifyContent: 'center',
       },
     } as IViewProps,
     content: {
@@ -34,19 +37,21 @@ export const settings: IComposeSettings<TabsItemType> = [
       style: {
         minHeight: 2,
         minWidth: 44,
+        // flex: 1,
         backgroundColor: '#185ABD',
-        // borderRadius: 2,
+        borderRadius: 2,
         // paddingTop: 5,
         // borderWidth: 1,
-        marginTop: 3,
+        marginBottom: 2,
       },
     },
     stack: {
       style: {
         display: 'flex',
-        paddingStart: 10,
-        paddingEnd: 10,
+        // paddingStart: 10,
+        // paddingEnd: 10,
         // paddingBottom: 50,
+        marginHorizontal: 10,
         alignItems: 'center',
         flexDirection: 'row',
         alignSelf: 'flex-start',
@@ -73,6 +78,8 @@ export const settings: IComposeSettings<TabsItemType> = [
           // backgroundColor: 'transparent',
           color: '#242424',
           // borderColor: 'buttonBorderHovered',
+          // fontWeight: 'bold',
+          // fontFamily: 'LargeSemibold',
           fontWeight: 'bold',
           fontFamily: 'Segoe UI',
           fontSize: 14,
@@ -97,16 +104,19 @@ export const settings: IComposeSettings<TabsItemType> = [
       focused: {
         tokens: {
           // borderColor: 'buttonBorderFocused',
-          color: '#242424', // invalid prop?
+          color: '#242424',
+          borderWidth: 2,
+          borderColor: '#242424',
+          borderRadius: 4,
           // backgroundColor: 'transparent',
           // borderWidth: 0,
         },
-        stack: {
-          style: {
-            borderWidth: 2,
-            borderColor: '#242424',
-          },
-        },
+        // stack: {
+        // style: {
+        // borderWidth: 2,
+        // borderColor: '#242424',
+        // },
+        // },
       },
     },
   },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -7,11 +7,11 @@ export const tabsItemSelectActionLabel = 'Select a TabsItem';
 export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
-      backgroundColor: 'buttonBackground',
-      color: 'buttonText',
-      borderColor: 'buttonBorder',
-      borderWidth: 1,
-      borderRadius: 2,
+      backgroundColor: 'transparent', // used to be 'buttonBackground'
+      color: 'black',
+      borderColor: 'black',
+      borderWidth: 0,
+      borderRadius: 0,
     },
     root: {
       accessible: true,
@@ -45,30 +45,38 @@ export const settings: IComposeSettings<TabsItemType> = [
     _overrides: {
       disabled: {
         tokens: {
-          backgroundColor: 'black',
+          backgroundColor: 'buttonBackgroundDisabled',
           color: 'buttonTextDisabled',
           borderColor: 'buttonBorderDisabled',
         },
       },
       hovered: {
         tokens: {
-          backgroundColor: 'green',
+          backgroundColor: 'transparent',
           color: 'buttonTextHovered',
           borderColor: 'buttonBorderHovered',
+          fontWeight: 'bold',
+          fontFamily: 'inherit',
+          fontSize: 13,
         },
       },
       selected: {
         tokens: {
-          backgroundColor: 'blue',
+          backgroundColor: 'transparent',
           color: 'buttonTextPressed',
           borderColor: 'buttonPressedBorder',
+          borderWidth: 0,
+          fontWeight: 'bold',
+          fontFamily: 'inherit',
+          fontSize: 13,
         },
       },
       focused: {
         tokens: {
-          borderColor: 'buttonBorderFocused',
-          color: 'buttonTextHovered',
-          backgroundColor: 'red',
+          borderColor: 'black',
+          color: 'buttonTextFocused',
+          backgroundColor: 'transparent',
+          borderWidth: 4,
         },
       },
     },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -8,9 +8,6 @@ export const tabsItemSelectActionLabel = 'Select a TabsItem';
 export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
-      // backgroundColor: 'transparent',
-      // borderColor: 'transparent',
-      // color: 'AccentDark',
       color: '#616161',
       borderWidth: 0,
       borderRadius: 0,
@@ -30,27 +27,19 @@ export const settings: IComposeSettings<TabsItemType> = [
         justifyContent: 'center',
       },
     } as IViewProps,
-    content: {
-      // accessible: false,
-    },
     indicator: {
       style: {
+        // flex: 1,
         minHeight: 2,
         minWidth: 44,
-        // flex: 1,
         backgroundColor: '#185ABD',
         borderRadius: 2,
-        // paddingTop: 5,
-        // borderWidth: 1,
         marginBottom: 2,
       },
     },
     stack: {
       style: {
         display: 'flex',
-        // paddingStart: 10,
-        // paddingEnd: 10,
-        // paddingBottom: 50,
         marginHorizontal: 10,
         alignItems: 'center',
         flexDirection: 'row',
@@ -58,10 +47,6 @@ export const settings: IComposeSettings<TabsItemType> = [
         minHeight: 32,
         minWidth: 32,
         justifyContent: 'center',
-        // borderWidth: 1,
-        // borderRadius: 2,
-        // backgroundColor: 'buttonBackground',
-        // borderColor: 'buttonBorder',
       },
     },
     _precedence: ['hovered', 'selected', 'focused', 'disabled'],
@@ -75,11 +60,7 @@ export const settings: IComposeSettings<TabsItemType> = [
       },
       hovered: {
         tokens: {
-          // backgroundColor: 'transparent',
           color: '#242424',
-          // borderColor: 'buttonBorderHovered',
-          // fontWeight: 'bold',
-          // fontFamily: 'LargeSemibold',
           fontWeight: 'bold',
           fontFamily: 'Segoe UI',
           fontSize: 14,
@@ -87,36 +68,19 @@ export const settings: IComposeSettings<TabsItemType> = [
       },
       selected: {
         tokens: {
-          // backgroundColor: 'transparent',
           color: '#242424',
-          // borderColor: 'buttonBorderPressed',
           fontWeight: 'bold',
           fontFamily: 'Segoe UI',
           fontSize: 14,
         },
-        // stack: {
-        //   style: {
-        //     borderWidth: 3,
-        //     borderColor: 'buttonBorderPressed',
-        //   },
-        // },
       },
       focused: {
         tokens: {
-          // borderColor: 'buttonBorderFocused',
           color: '#242424',
           borderWidth: 2,
           borderColor: '#242424',
           borderRadius: 4,
-          // backgroundColor: 'transparent',
-          // borderWidth: 0,
         },
-        // stack: {
-        // style: {
-        // borderWidth: 2,
-        // borderColor: '#242424',
-        // },
-        // },
       },
     },
   },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -7,14 +7,14 @@ export const tabsItemSelectActionLabel = 'Select a TabsItem';
 export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
-      backgroundColor: 'transparent',
-      color: 'buttonText',
-      borderColor: 'buttonTextPressed',
+      // backgroundColor: 'transparent',
+      color: '#616161',
+      // borderColor: 'transparent',
       borderWidth: 0,
       borderRadius: 0,
       fontSize: 14,
       fontWeight: 'normal',
-      fontFamily: 'inherit',
+      fontFamily: 'Segoe UI',
     },
     root: {
       accessible: true,
@@ -35,6 +35,10 @@ export const settings: IComposeSettings<TabsItemType> = [
         minHeight: 2,
         minWidth: 44,
         backgroundColor: '#185ABD',
+        // borderRadius: 2,
+        // paddingTop: 5,
+        // borderWidth: 1,
+        marginTop: 3,
       },
     },
     stack: {
@@ -42,16 +46,17 @@ export const settings: IComposeSettings<TabsItemType> = [
         display: 'flex',
         paddingStart: 10,
         paddingEnd: 10,
+        // paddingBottom: 50,
         alignItems: 'center',
         flexDirection: 'row',
         alignSelf: 'flex-start',
         minHeight: 32,
         minWidth: 32,
         justifyContent: 'center',
-        borderWidth: 1,
-        borderRadius: 2,
-        backgroundColor: 'buttonBackground',
-        borderColor: 'buttonBorder',
+        // borderWidth: 1,
+        // borderRadius: 2,
+        // backgroundColor: 'buttonBackground',
+        // borderColor: 'buttonBorder',
       },
     },
     _precedence: ['hovered', 'selected', 'focused', 'disabled'],
@@ -65,31 +70,42 @@ export const settings: IComposeSettings<TabsItemType> = [
       },
       hovered: {
         tokens: {
-          backgroundColor: 'transparent',
-          color: 'buttonTextHovered',
-          borderColor: 'buttonBorderHovered',
+          // backgroundColor: 'transparent',
+          color: '#242424',
+          // borderColor: 'buttonBorderHovered',
           fontWeight: 'bold',
-          fontFamily: 'inherit',
+          fontFamily: 'Segoe UI',
           fontSize: 14,
         },
       },
       selected: {
         tokens: {
-          backgroundColor: 'transparent',
-          color: 'buttonTextPressed',
+          // backgroundColor: 'transparent',
+          color: '#242424',
           // borderColor: 'buttonBorderPressed',
-          borderWidth: 0,
           fontWeight: 'bold',
-          fontFamily: 'inherit',
+          fontFamily: 'Segoe UI',
           fontSize: 14,
         },
+        // stack: {
+        //   style: {
+        //     borderWidth: 3,
+        //     borderColor: 'buttonBorderPressed',
+        //   },
+        // },
       },
       focused: {
         tokens: {
-          borderColor: 'buttonBorderFocused',
-          color: 'buttonTextFocused', // invalid prop?
-          backgroundColor: 'transparent',
-          borderWidth: 3,
+          // borderColor: 'buttonBorderFocused',
+          color: '#242424', // invalid prop?
+          // backgroundColor: 'transparent',
+          // borderWidth: 0,
+        },
+        stack: {
+          style: {
+            borderWidth: 2,
+            borderColor: '#242424',
+          },
         },
       },
     },

--- a/packages/components/Tabs/src/TabsItem.tsx
+++ b/packages/components/Tabs/src/TabsItem.tsx
@@ -18,6 +18,7 @@ import {
   createIconProps,
   useOnPressWithFocus,
 } from '@fluentui-react-native/interactive-hooks';
+// import { Separator } from '@fluentui/react-native';
 
 export const TabsItem = compose<TabsItemType>({
   displayName: tabsItemName,
@@ -134,7 +135,7 @@ export const TabsItem = compose<TabsItemType>({
           {info.headerText && <Slots.content />}
           {children}
         </Slots.stack>
-        {info.selected && <Slots.indicator />}
+        <Slots.indicator />
       </Slots.root>
     );
   },

--- a/packages/components/Tabs/src/TabsItem.tsx
+++ b/packages/components/Tabs/src/TabsItem.tsx
@@ -145,7 +145,7 @@ export const TabsItem = compose<TabsItemType>({
     stack: { slotType: View, filter: filterViewProps },
     icon: { slotType: Icon as React.ComponentType<object> },
     content: Text,
-    indicator: View,
+    indicator: { slotType: View, filter: filterViewProps },
   },
   styles: {
     root: [backgroundColorTokens, borderTokens],

--- a/packages/components/Tabs/src/TabsItem.tsx
+++ b/packages/components/Tabs/src/TabsItem.tsx
@@ -18,7 +18,6 @@ import {
   createIconProps,
   useOnPressWithFocus,
 } from '@fluentui-react-native/interactive-hooks';
-// import { Separator } from '@fluentui/react-native';
 
 export const TabsItem = compose<TabsItemType>({
   displayName: tabsItemName,

--- a/packages/components/Tabs/src/TabsItem.tsx
+++ b/packages/components/Tabs/src/TabsItem.tsx
@@ -134,6 +134,7 @@ export const TabsItem = compose<TabsItemType>({
           {info.headerText && <Slots.content />}
           {children}
         </Slots.stack>
+        {/* {info.selected && <Slots.bottomStyle />} */}
       </Slots.root>
     );
   },
@@ -144,6 +145,7 @@ export const TabsItem = compose<TabsItemType>({
     stack: { slotType: View, filter: filterViewProps },
     icon: { slotType: Icon as React.ComponentType<object> },
     content: Text,
+    // bottomStyle: Text,
   },
   styles: {
     root: [backgroundColorTokens, borderTokens],


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

(a summary of the changes made, often organized by file)

TabsItem.settings.ts
made the styling work correctly for 'hovered', 'selected', 'focused', 'disabled'
cleaned up comments and code

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
after:
![image](https://user-images.githubusercontent.com/25557846/127408969-82d89a28-3852-4e42-885b-8a8c7c115809.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
