### PR TITLE
Fixed disabled tabItem being selected by default if the first tabItem…

### DIFF
--- a/packages/components/Tabs/src/Tabs.tsx
+++ b/packages/components/Tabs/src/Tabs.tsx
@@ -108,7 +108,8 @@ export const Tabs = compose<TabsType>({
       // @ts-ignore - TODO, fix typing error
       renderData.state.context.tabsItemKeys = React.Children.map(children, (child: React.ReactChild) => {
         if (React.isValidElement(child)) {
-          if (renderData.state.context.selectedKey == null) {
+          // Sets default selected tabItem
+          if (renderData.state.context.selectedKey == null && !child.props.disabled) {
             renderData.state.context.selectedKey = child.props.itemKey;
           }
           return child.props.itemKey;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [*] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Made item tab being disabled respect the default selected tab

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
