### PR TITLE
Stylingv2

### DIFF
--- a/packages/components/Tabs/src/Tabs.settings.ts
+++ b/packages/components/Tabs/src/Tabs.settings.ts
@@ -21,7 +21,7 @@ export const settings: IComposeSettings<TabsType> = [
     container: {
       style: {
         flexDirection: 'row',
-        backgroundColor: '#FAFAFA',
+        // backgroundColor: '#FAFAFA',
       },
     },
   },

--- a/packages/components/Tabs/src/Tabs.settings.ts
+++ b/packages/components/Tabs/src/Tabs.settings.ts
@@ -21,7 +21,6 @@ export const settings: IComposeSettings<TabsType> = [
     container: {
       style: {
         flexDirection: 'row',
-        // backgroundColor: '#FAFAFA',
       },
     },
   },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -7,7 +7,7 @@ export const tabsItemSelectActionLabel = 'Select a TabsItem';
 export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
-      color: '#616161',
+      color: 'neutralForeground3Brand',
       variant: 'bodyStandard',
     },
     root: {
@@ -47,34 +47,34 @@ export const settings: IComposeSettings<TabsItemType> = [
     _overrides: {
       disabled: {
         tokens: {
-          color: '#BDBDBD',
+          color: 'neutralForegroundDisabled',
         },
       },
       hovered: {
         tokens: {
-          color: '#242424',
+          color: 'neutralForeground2Hover',
         },
         indicator: {
           style: {
-            backgroundColor: '#D1D1D1',
+            backgroundColor: 'neutralStroke1',
           },
         },
       },
       selected: {
         tokens: {
-          color: '#242424',
+          color: 'neutralForeground1',
           variant: 'bodySemibold',
         },
         indicator: {
           style: {
-            backgroundColor: '#0078D4',
+            backgroundColor: 'brandStroke1',
           },
         },
         _overrides: {
           pressed: {
             indicator: {
               style: {
-                backgroundColor: '#D1D1D1',
+                backgroundColor: 'neutralStroke1',
               },
             },
           },
@@ -83,25 +83,25 @@ export const settings: IComposeSettings<TabsItemType> = [
 
       pressed: {
         tokens: {
-          color: '#242424',
+          color: 'neutralForeground2Pressed',
         },
         indicator: {
           style: {
-            backgroundColor: '#0078D4',
+            backgroundColor: 'brandStroke1',
           },
         },
       },
 
       focused: {
         tokens: {
-          color: '#242424',
+          color: 'neutralForeground1',
           borderWidth: 2,
-          borderColor: '#242424',
+          borderColor: 'neutralForeground1',
           borderRadius: 4,
         },
         indicator: {
           style: {
-            backgroundColor: '#0078D4',
+            backgroundColor: 'brandStroke1',
           },
         },
       },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -1,7 +1,6 @@
 import { tabsItemName, TabsItemType } from './TabsItem.types';
 import { IComposeSettings } from '@uifabricshared/foundation-compose';
 import type { IViewProps } from '@fluentui-react-native/adapters';
-// import { Text } from '@fluentui-react-native/experimental-text';
 
 export const tabsItemSelectActionLabel = 'Select a TabsItem';
 
@@ -9,16 +8,12 @@ export const settings: IComposeSettings<TabsItemType> = [
   {
     tokens: {
       color: '#616161',
-      fontWeight: 'normal',
-      fontFamily: 'Segoe UI',
-      borderWidth: 0,
-      borderRadius: 0,
-      fontSize: 14,
+      variant: 'bodyStandard',
     },
     root: {
       accessible: true,
       focusable: true,
-      accessibilityRole: 'tab',
+      accessibilityRole: 'button',
       style: {
         display: 'flex',
         alignItems: 'center',
@@ -29,17 +24,15 @@ export const settings: IComposeSettings<TabsItemType> = [
     } as IViewProps,
     indicator: {
       style: {
-        // flex: 1,
         minHeight: 2,
-        minWidth: 44,
         backgroundColor: 'transparent',
         borderRadius: 2,
         marginBottom: 2,
+        alignSelf: 'stretch',
       },
     },
     stack: {
       style: {
-        // backgroundColor: '#FAFAFA',
         display: 'flex',
         marginHorizontal: 10,
         alignItems: 'center',
@@ -50,21 +43,16 @@ export const settings: IComposeSettings<TabsItemType> = [
         justifyContent: 'center',
       },
     },
-    _precedence: ['hovered', 'pressed', 'selected', 'focused', 'disabled'],
+    _precedence: ['selected', 'hovered', 'focused', 'disabled', 'pressed'],
     _overrides: {
       disabled: {
         tokens: {
-          // backgroundColor: 'buttonBackgroundDisabled',
           color: '#BDBDBD',
-          // borderColor: 'buttonBorderDisabled',
         },
       },
       hovered: {
         tokens: {
           color: '#242424',
-          // fontWeight: 'bold',
-          // fontFamily: 'Segoe UI',
-          // fontSize: 14,
         },
         indicator: {
           style: {
@@ -75,11 +63,24 @@ export const settings: IComposeSettings<TabsItemType> = [
       selected: {
         tokens: {
           color: '#242424',
-          fontWeight: 'bold',
-          fontFamily: 'Segoe UI',
-          fontSize: 14,
+          variant: 'bodySemibold',
+        },
+        indicator: {
+          style: {
+            backgroundColor: '#0078D4',
+          },
+        },
+        _overrides: {
+          pressed: {
+            indicator: {
+              style: {
+                backgroundColor: '#D1D1D1',
+              },
+            },
+          },
         },
       },
+
       pressed: {
         tokens: {
           color: '#242424',
@@ -90,6 +91,7 @@ export const settings: IComposeSettings<TabsItemType> = [
           },
         },
       },
+
       focused: {
         tokens: {
           color: '#242424',

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -56,7 +56,8 @@ export const settings: IComposeSettings<TabsItemType> = [
         },
         indicator: {
           style: {
-            backgroundColor: 'neutralStroke1',
+            // backgroundColor: 'neutralStroke1',
+            backgroundColor: '#D1D1D1',
           },
         },
       },
@@ -67,14 +68,16 @@ export const settings: IComposeSettings<TabsItemType> = [
         },
         indicator: {
           style: {
-            backgroundColor: 'brandStroke1',
+            // backgroundColor: 'brandStroke1',
+            backgroundColor: '#0078D4',
           },
         },
         _overrides: {
           pressed: {
             indicator: {
               style: {
-                backgroundColor: 'neutralStroke1',
+                // backgroundColor: 'neutralStroke1',
+                backgroundColor: '#D1D1D1',
               },
             },
           },
@@ -87,7 +90,8 @@ export const settings: IComposeSettings<TabsItemType> = [
         },
         indicator: {
           style: {
-            backgroundColor: 'brandStroke1',
+            // backgroundColor: 'brandStroke1',
+            backgroundColor: '#0078D4',
           },
         },
       },
@@ -101,7 +105,8 @@ export const settings: IComposeSettings<TabsItemType> = [
         },
         indicator: {
           style: {
-            backgroundColor: 'brandStroke1',
+            // backgroundColor: 'brandStroke1',
+            backgroundColor: '#0078D4',
           },
         },
       },

--- a/packages/components/Tabs/src/TabsItem.settings.ts
+++ b/packages/components/Tabs/src/TabsItem.settings.ts
@@ -9,6 +9,10 @@ export const settings: IComposeSettings<TabsItemType> = [
     tokens: {
       color: 'neutralForeground3Brand',
       variant: 'bodyStandard',
+      borderWidth: 2,
+      // borderColor: 'neutralForeground1',
+      borderColor: 'transparent',
+      borderRadius: 4,
     },
     root: {
       accessible: true,
@@ -29,6 +33,7 @@ export const settings: IComposeSettings<TabsItemType> = [
         borderRadius: 2,
         marginBottom: 2,
         alignSelf: 'stretch',
+        marginHorizontal: 10,
       },
     },
     stack: {
@@ -99,9 +104,7 @@ export const settings: IComposeSettings<TabsItemType> = [
       focused: {
         tokens: {
           color: 'neutralForeground1',
-          borderWidth: 2,
           borderColor: 'neutralForeground1',
-          borderRadius: 4,
         },
         indicator: {
           style: {

--- a/packages/components/Tabs/src/TabsItem.tsx
+++ b/packages/components/Tabs/src/TabsItem.tsx
@@ -42,7 +42,7 @@ export const TabsItem = compose<TabsItemType>({
     const changeSelection = () => {
       if (itemKey != info.selectedKey) {
         info.onTabsClick && info.onTabsClick(itemKey);
-        info.getTabId && info.getTabId(itemKey, info.tabsItemKeys.findIndex(x => x == itemKey) + 1);
+        info.getTabId && info.getTabId(itemKey, info.tabsItemKeys.findIndex((x) => x == itemKey) + 1);
         info.updateSelectedTabsItemRef && componentRef && info.updateSelectedTabsItemRef(componentRef);
       }
     };
@@ -106,7 +106,7 @@ export const TabsItem = compose<TabsItemType>({
         accessibilityLabel: accessibilityLabel,
         accessibilityState: { disabled: state.info.disabled, selected: state.info.selected },
         accessibilityActions: [{ name: 'Select', label: tabsItemSelectActionLabel }],
-        accessibilityPositionInSet: info.tabsItemKeys.findIndex(x => x == itemKey) + 1,
+        accessibilityPositionInSet: info.tabsItemKeys.findIndex((x) => x == itemKey) + 1,
         accessibilitySetSize: info.tabsItemKeys.length,
         onAccessibilityAction: onAccessibilityAction,
         onKeyUp: onKeyUp,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

(a summary of the changes made, often organized by file)
TabsItem.settings.ts
- Improved styling for functionalities like hovered, selected, focused, pressed, disabled
- used some tokens and some that weren't working were hardcoded hex values
- styling bugs resolved

TabsItem.tsx
- added / removed tokens

Tabs.settings.ts
- removed background color

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
![image](https://user-images.githubusercontent.com/25557846/127577401-062832a0-08c8-417b-bbfe-e78564bf8fba.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
